### PR TITLE
Bump minimum CMake version to 3.29 in smart-light

### DIFF
--- a/smart-light/CMakeLists.txt
+++ b/smart-light/CMakeLists.txt
@@ -1,6 +1,6 @@
 # The following lines of boilerplate have to be in your project's
 # CMakeLists in this exact order for cmake to work correctly
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.29)
 
 if(NOT DEFINED ENV{ESP_MATTER_PATH})
     message(FATAL_ERROR "Please set ESP_MATTER_PATH to the path of esp-matter repo")


### PR DESCRIPTION
Fixes https://github.com/apple/swift-matter-examples/issues/6