### PR TITLE
Avoid local variable cleanup in app_main

### DIFF
--- a/smart-light/main/Main.swift
+++ b/smart-light/main/Main.swift
@@ -59,4 +59,10 @@ func app_main() {
   let app = Matter.Application()
   app.rootNode = rootNode
   app.start()
+
+  // Keep local variables alive. Workaround for issue #10
+  // https://github.com/apple/swift-matter-examples/issues/10
+  while true {
+    sleep(1)
+  }
 }


### PR DESCRIPTION
Workaround as discussed in https://github.com/apple/swift-matter-examples/issues/10#issuecomment-2198496662

Avoid cleanup of local variables which are (weakly) referenced by esp-matter