### PR TITLE
Add `Xcc` flags that fixes crash on ESP32-C3.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ Before running the examples, ensure you have the following tools available:
 
 - Hardware:
   - [ESP32-C6-DevKitC-1-N8](https://docs.espressif.com/projects/espressif-esp-dev-kits/en/latest/esp32c6/esp32-c6-devkitc-1/user_guide.html)
-  - The `smart-light` example is also tested using [Wemos C3 mini](https://www.wemos.cc/en/latest/c3/c3_mini.html)
 - Software
   - [Swift Nightly Toolchain](https://www.swift.org/download)
   - [CMake 3.29+](https://cmake.org/download)
@@ -60,14 +59,9 @@ Ensure your shell has access to the tools listed above, see [Get started on macO
   $ cd swift-matter-examples/smart-light
   ```
 
-2. Configure the build system for your microcontroller.
+2. Configure the build system for your microcontroller, the `smart-light` example should also be runnable on `esp32c3`.
   ```shell
   $ idf.py set-target esp32c6
-  ```
-
-or (if using ESP32C3)
-  ```shell
-  $ idf.py set-target esp32c3
   ```
 
 3. Build and deploy the application to your device.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Build a Matter accessory using Embedded Swift
 
 <!-- Image -->
 
-This repository contains an example simple Embedded Swift application that implements a Matter smart light accessory and can be used from HomeKit. The examples use an ESP32-C6 (RISC-V) microcontroller and build on top of the ESP-IDF and ESP-Matter SDKs.
+This repository contains an example simple Embedded Swift application that implements a Matter smart light accessory and can be used from HomeKit. The examples use an ESP32-C6 or ESP32-C3 (RISC-V) microcontroller and build on top of the ESP-IDF and ESP-Matter SDKs.
 
 > [!NOTE]
 > This repository is associated with WWDC24 session 10197: [Go small with Embedded Swift](https://developer.apple.com/wwdc24/10197).
@@ -37,7 +37,8 @@ Before running the examples, ensure you have the following tools available:
 
 - Hardware:
   - [ESP32-C6-DevKitC-1-N8](https://docs.espressif.com/projects/espressif-esp-dev-kits/en/latest/esp32c6/esp32-c6-devkitc-1/user_guide.html)
-- Software 
+  - The `smart-light` example is also tested using [Wemos C3 mini](https://www.wemos.cc/en/latest/c3/c3_mini.html)
+- Software
   - [Swift Nightly Toolchain](https://www.swift.org/download)
   - [CMake 3.29+](https://cmake.org/download)
   - [ESP-IDF 5.2.1](https://docs.espressif.com/projects/esp-idf/en/v5.2.1/esp32c6/get-started/index.html)
@@ -64,12 +65,17 @@ Ensure your shell has access to the tools listed above, see [Get started on macO
   $ idf.py set-target esp32c6
   ```
 
-3. Build and deploy the application to your device. 
+or (if using ESP32C3)
+  ```shell
+  $ idf.py set-target esp32c3
+  ```
+
+3. Build and deploy the application to your device.
   ```shell
   $ idf.py build flash monitor
   ```
 
-Explore the implementation, see [Explore the LED Blink example](https://apple.github.io/swift-matter-examples/tutorials/swiftmatterexamples/run-example-led-blink#Understand-the-code) and 
+Explore the implementation, see [Explore the LED Blink example](https://apple.github.io/swift-matter-examples/tutorials/swiftmatterexamples/run-example-led-blink#Understand-the-code) and
 [Explore the Smart Light example](https://apple.github.io/swift-matter-examples/tutorials/swiftmatterexamples/run-example-smart-light#Understand-the-code) for guided walkthroughs.
 
 ## Contributing to Swift Matter Examples

--- a/smart-light/README.md
+++ b/smart-light/README.md
@@ -37,14 +37,9 @@ For full steps how to build the example code, follow the [Setup Your Environment
   $ cd swift-matter-examples/smart-light
   ```
 
-2. Configure the build system for your microcontroller.
+2. Configure the build system for your microcontroller, this example should also be runnable on `esp32c3`.
   ```shell
   $ idf.py set-target esp32c6
-  ```
-
-or (if using ESP32C3)
-  ```shell
-  $ idf.py set-target esp32c3
   ```
 
 3. Build and deploy the application to your device.

--- a/smart-light/README.md
+++ b/smart-light/README.md
@@ -1,6 +1,6 @@
 # Embedded Swift Matter Example: Smart Light example
 
-This directory contains an example implementation of a Matter smart LED light accessory in Embedded Swift, and it can be built using the ESP IDF and ESP Matter SDKs, and uploaded to an ESP32C6 development board.
+This directory contains an example implementation of a Matter smart LED light accessory in Embedded Swift, and it can be built using the ESP IDF and ESP Matter SDKs, and uploaded to an ESP32C6 or ESP32C3 development board.
 
 Breakdown of the files included:
 
@@ -27,7 +27,7 @@ Breakdown of the files included:
 For full steps how to build the example code, follow the [Setup Your Environment](https://apple.github.io/swift-embedded/swift-matter-examples/tutorials/tutorial-table-of-contents#setup-your-environment) tutorials and the [Explore the Smart Light example](https://apple.github.io/swift-matter-examples/tutorials/swiftmatterexamples/run-example-smart-light) tutorial. In summary:
 
 - Ensure your system has all the required software installed and your shell has access to the tools listed in the top-level README file.
-- Plug in the ESP32C6 development board via a USB cable.
+- Plug in the ESP32C6/C3 development board via a USB cable.
 - Have a set up HomeKit or other Matter-enabled smart home ecosystem.
   - For HomeKit, this includes a configured home, a Wi-Fi network which additional devices can join, a [home hub](https://support.apple.com/en-us/102557), and an iOS device for managing the home.
 
@@ -42,12 +42,17 @@ For full steps how to build the example code, follow the [Setup Your Environment
   $ idf.py set-target esp32c6
   ```
 
-3. Build and deploy the application to your device. 
+or (if using ESP32C3)
+  ```shell
+  $ idf.py set-target esp32c3
+  ```
+
+3. Build and deploy the application to your device.
   ```shell
   $ idf.py build flash monitor
   ```
 
-4. Register the device in your home network. See [Connect-using-Matter](https://apple.github.io/swift-matter-examples/tutorials/swiftmatterexamples/run-example-smart-light#Connect-using-Matter) for detailed pairing instructions with HomeKit. 
+4. Register the device in your home network. See [Connect-using-Matter](https://apple.github.io/swift-matter-examples/tutorials/swiftmatterexamples/run-example-smart-light#Connect-using-Matter) for detailed pairing instructions with HomeKit.
 
 5. You can now control the smart light. In case of a HomeKit network, the Home app, and Siri can both be used to turn the light on, off, change colors, etc.
 

--- a/smart-light/main/CMakeLists.txt
+++ b/smart-light/main/CMakeLists.txt
@@ -46,6 +46,8 @@ target_compile_options(${COMPONENT_LIB} PUBLIC "$<$<COMPILE_LANGUAGE:Swift>:SHEL
         -Xcc -D_GLIBCXX_HAVE_POSIX_SEMAPHORE 
         -Xcc -D_GLIBCXX_USE_POSIX_SEMAPHORE 
         -Xcc -D_POSIX_READER_WRITER_LOCKS
+        -Xcc -march=rv32imc_zicsr_zifencei
+        -Xcc -mabi=ilp32
 
         -pch-output-dir /tmp
         -Xfrontend -enable-single-module-llvm-emission

--- a/smart-light/main/CMakeLists.txt
+++ b/smart-light/main/CMakeLists.txt
@@ -22,6 +22,19 @@ foreach(dir ${CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES})
     string(CONCAT SWIFT_INCLUDES ${SWIFT_INCLUDES} "-I${dir} ")
 endforeach()
 
+# Set device-specific march/mabi flags
+idf_build_get_property(target IDF_TARGET)
+if(${target} STREQUAL "esp32c2" OR ${target} STREQUAL "esp32c3")
+    set(march_flag "rv32imc_zicsr_zifencei")
+    set(mabi_flag "ilp32")
+elseif(${target} STREQUAL "esp32p4")
+    set(march_flag "rv32imafc_zicsr_zifencei")
+    set(mabi_flag "ilp32f")
+else()
+    set(march_flag "rv32imac_zicsr_zifencei")
+    set(mabi_flag "ilp32")
+endif()
+
 # Swift compiler flags to build in Embedded Swift mode, optimize for size, choose the right ISA, ABI, C++ language standard, etc.
 target_compile_options(${COMPONENT_LIB} PUBLIC "$<$<COMPILE_LANGUAGE:Swift>:SHELL:
         -target riscv32-none-none-eabi
@@ -46,8 +59,8 @@ target_compile_options(${COMPONENT_LIB} PUBLIC "$<$<COMPILE_LANGUAGE:Swift>:SHEL
         -Xcc -D_GLIBCXX_HAVE_POSIX_SEMAPHORE 
         -Xcc -D_GLIBCXX_USE_POSIX_SEMAPHORE 
         -Xcc -D_POSIX_READER_WRITER_LOCKS
-        -Xcc -march=rv32imc_zicsr_zifencei
-        -Xcc -mabi=ilp32
+        -Xcc -march=${march_flag}
+        -Xcc -mabi=${mabi_flag}
 
         -pch-output-dir /tmp
         -Xfrontend -enable-single-module-llvm-emission


### PR DESCRIPTION
This fixes #15, making the `smart-light` example run on ESP32-C3.

I'm don't have enough knowledge to know if this is the proper fix/correct location to add these flags, but it makes the example work for me at least.
