### PR TITLE
Update the ESP-IDF tooling to master (or v5.4 when released) to fix Embedded Swift Crashes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,11 @@ RUN apt-get update \
 # Install CMake >= 3.29
 RUN pip install --upgrade cmake
 
-# Download ESP-IDF
+# Download the ESP-IDF SDK (`master` or `v5.4` when released)
 RUN mkdir -p ~/esp \
   && cd ~/esp \
   && git clone \
-    --branch v5.2.1 \
+    --branch master \
     --depth 1 \
     --shallow-submodules \
     --recursive https://github.com/espressif/esp-idf.git \

--- a/Sources/SwiftMatterExamples/Documentation.docc/Resources/install-esp-terminal/install-esp-terminal-03.sh
+++ b/Sources/SwiftMatterExamples/Documentation.docc/Resources/install-esp-terminal/install-esp-terminal-03.sh
@@ -7,10 +7,10 @@ $ brew install cmake ninja dfu-util
 # Create an ESP SDK directory
 $ mkdir -p ~/esp
 
-# Download the ESP-IDF SDK
+# Download the ESP-IDF SDK (`master` or `v5.4` when released)
 $ cd ~/esp
 $ git clone \
-  --branch v5.2.1 \
+  --branch master \
   --depth 1 \
   --shallow-submodules \
   --recursive https://github.com/espressif/esp-idf.git \

--- a/Sources/SwiftMatterExamples/Documentation.docc/Resources/install-esp-terminal/install-esp-terminal-04.sh
+++ b/Sources/SwiftMatterExamples/Documentation.docc/Resources/install-esp-terminal/install-esp-terminal-04.sh
@@ -7,10 +7,10 @@ $ brew install cmake ninja dfu-util
 # Create an ESP SDK directory
 $ mkdir -p ~/esp
 
-# Download the ESP-IDF SDK
+# Download the ESP-IDF SDK (`master` or `v5.4` when released)
 $ cd ~/esp
 $ git clone \
-  --branch v5.2.1 \
+  --branch master \
   --depth 1 \
   --shallow-submodules \
   --recursive https://github.com/espressif/esp-idf.git \

--- a/Sources/SwiftMatterExamples/Documentation.docc/Resources/install-esp-terminal/install-esp-terminal-05.sh
+++ b/Sources/SwiftMatterExamples/Documentation.docc/Resources/install-esp-terminal/install-esp-terminal-05.sh
@@ -7,10 +7,10 @@ $ brew install cmake ninja dfu-util
 # Create an ESP SDK directory
 $ mkdir -p ~/esp
 
-# Download the ESP-IDF SDK
+# Download the ESP-IDF SDK (`master` or `v5.4` when released)
 $ cd ~/esp
 $ git clone \
-  --branch v5.2.1 \
+  --branch master \
   --depth 1 \
   --shallow-submodules \
   --recursive https://github.com/espressif/esp-idf.git \

--- a/Sources/SwiftMatterExamples/Documentation.docc/Resources/install-esp-terminal/install-esp-terminal-06.sh
+++ b/Sources/SwiftMatterExamples/Documentation.docc/Resources/install-esp-terminal/install-esp-terminal-06.sh
@@ -7,10 +7,10 @@ $ brew install cmake ninja dfu-util
 # Create an ESP SDK directory
 $ mkdir -p ~/esp
 
-# Download the ESP-IDF SDK
+# Download the ESP-IDF SDK (`master` or `v5.4` when released)
 $ cd ~/esp
 $ git clone \
-  --branch v5.2.1 \
+  --branch master \
   --depth 1 \
   --shallow-submodules \
   --recursive https://github.com/espressif/esp-idf.git \

--- a/Sources/SwiftMatterExamples/Documentation.docc/Tutorials/Setup-MacOS.tutorial
+++ b/Sources/SwiftMatterExamples/Documentation.docc/Tutorials/Setup-MacOS.tutorial
@@ -83,7 +83,7 @@
     @ContentAndMedia {
       Install the tools and SDKs needed to build an ESP32-C6 Matter accessory.
       
-      The steps here should be enough to get started quickly, but for additional detailed instructions see the official [ESP-IDF Setup](https://docs.espressif.com/projects/esp-idf/en/v5.2.1/esp32/get-started/linux-macos-setup.html) and [ESP-Matter Setup](https://docs.espressif.com/projects/esp-matter/en/latest/esp32/developing.html#esp-matter-setup) documentation.
+      The steps here should be enough to get started quickly, but for additional detailed instructions see the official [ESP-IDF Setup](https://docs.espressif.com/projects/esp-idf/en/v5.3.1/esp32/get-started/linux-macos-setup.html) and [ESP-Matter Setup](https://docs.espressif.com/projects/esp-matter/en/latest/esp32/developing.html#esp-matter-setup) documentation.
     }
 
     @Steps {
@@ -108,7 +108,7 @@
       }
       
       @Step {
-        Clone the ESP-IDF repository version 5.2.1 from GitHub.
+        Clone the ESP-IDF `master` branch (5.4 when released) from GitHub.
         
         Note this SDK is quite large (~500 MB for a shallow clone) and may take significant time to download depending on your internet connection.
         


### PR DESCRIPTION
Fixes Embedded Swift issues. Random numbers do not work on 5.1.2 - 5.3.1 in addition to several issues.

Note: The fix is on master, but we don't have a 5.4 release yet. Since Embedded Swift is experimental, it makes sense to be recommending tooling that solves current problems. There is some risk in not having a stable ESP-IDF release.

> Please stay in the master (v5.4) branch. Don't checkout to the release v5.2 or v5.3
> As a summary;
> We have fixed the The gap between ...  errors in this repo with the 2eb2975 . No change in the IDF releases.
> We don't have getentropy error in IDF master (v5.4) branch. No need to apply a patch.
> For the previous idf releases (v5.3.x and v5.2.x), apply the patch I prepared. https://github.com/user-attachments/files/15877608/0001-newlib-getentropy-implementation.patch

https://github.com/apple/swift-embedded-examples/issues/17#issuecomment-2348454444