### PR TITLE
fix: Added GIT_CLONE_JOBS ARG to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 # Start from the latest Swift nightly main toolchain
 FROM swiftlang/swift:nightly-main-jammy
 
+# The number of submodules fetched at the same time
+ARG GIT_CLONE_JOBS=24
+
 # Install ESP-IDF dependencies
 RUN apt-get update \
   && apt-get install --yes --no-install-recommends \
@@ -19,7 +22,7 @@ RUN mkdir -p ~/esp \
     --depth 1 \
     --shallow-submodules \
     --recursive https://github.com/espressif/esp-idf.git \
-    --jobs 24
+    --jobs $GIT_CLONE_JOBS
 
 # Install ESP-IDF
 RUN cd ~/esp/esp-idf \
@@ -41,7 +44,7 @@ RUN mkdir -p ~/esp \
     --depth 1 \
     --shallow-submodules \
     --recursive https://github.com/espressif/esp-matter.git \
-    --jobs 24
+    --jobs $GIT_CLONE_JOBS
 
 # Download ESP-Matter
 RUN mkdir -p ~/esp \


### PR DESCRIPTION
This value was hardcoded and was too high for some systems.

I would get the following error
```
Cloning into '/root/esp/esp-matter/connectedhomeip/connectedhomeip/third_party/pigweed/repo'...
Cloning into '/root/esp/esp-matter/connectedhomeip/connectedhomeip/third_party/infineon/psoc6/psoc6_sdk/libs/btstack'...
Cloning into '/root/esp/esp-matter/connectedhomeip/connectedhomeip/third_party/ti_simplelink_sdk/repo_cc32xx'...
error: RPC failed; curl 92 HTTP/2 stream 0 was not closed cleanly: CANCEL (err 8)
error: 7349 bytes of body are still expected
fetch-pack: unexpected disconnect while reading sideband packet
fatal: early EOF
fatal: fetch-pack: invalid index-pack output
fatal: clone of 'https://github.com/TexasInstruments/cc32xx_open_sdk.git' into submodule path '/root/esp/esp-matter/connectedhomeip/connectedhomeip/third_party/ti_simplelink_sdk/repo_cc32xx' failed
Failed to clone 'third_party/ti_simplelink_sdk/repo_cc32xx'. Retry scheduled
Cloning into '/root/esp/esp-matter/connectedhomeip/connectedhomeip/third_party/infineon/psoc6/psoc6_sdk/libs/wifi-host-driver'...
Cloning into '/root/esp/esp-matter/connectedhomeip/connectedhomeip/third_party/infineon/psoc6/psoc6_sdk/libs/mtb-pdl-cat1'...
Cloning into '/root/esp/esp-matter/connectedhomeip/connectedhomeip/third_party/boringssl/repo/src'...
error: RPC failed; curl 92 HTTP/2 stream 0 was not closed cleanly: CANCEL (err 8)
error: 7443 bytes of body are still expected
fetch-pack: unexpected disconnect while reading sideband packet
fatal: early EOF
fatal: fetch-pack: invalid index-pack output
```

The image builds correctly when I lower the job count to 2
```
docker build . --tag swift-matter-examples-builder --build-arg GIT_CLONE_JOBS=2
```