### PR TITLE
Fix smart-light building issue

### DIFF
--- a/smart-light/main/CMakeLists.txt
+++ b/smart-light/main/CMakeLists.txt
@@ -2,6 +2,7 @@
 idf_component_register(
     SRCS "../Matter/MatterInterface.cpp"
     PRIV_INCLUDE_DIRS "."
+    LDFRAGMENTS "linker.lf"
 )
 
 # Clear the default COMPILE_OPTIONS which include a lot of C/C++ specific compiler flags that the Swift compiler will not accept

--- a/smart-light/main/linker.lf
+++ b/smart-light/main/linker.lf
@@ -1,0 +1,17 @@
+[sections:flash_text_swift]
+entries:
+    .swift_modhash+
+[sections:dram0_swift]
+entries:
+    .got+
+    .got.plt+
+[scheme:swift_default]
+entries:
+    flash_text_swift -> flash_text
+    dram0_swift -> dram0_data
+[mapping:swift_default]
+archive: *
+entries:
+    * (swift_default);
+    flash_text_swift -> flash_text SURROUND (swift_text),
+    dram0_swift -> dram0_data SURROUND (swift_dram0)


### PR DESCRIPTION
This fix is inspired by https://github.com/apple/swift-embedded-examples/commit/2eb29759860c4f1e6b22c5f4d1f8e76a8086adcc described in https://github.com/apple/swift-embedded-examples/issues/17.

It solves the following problem that occurs when running `idf.py build`:
```
[7/9] Linking CXX executable light.elf
FAILED: light.elf 
...
/Users/****/.espressif/tools/riscv32-esp-elf/esp-14.2.0_20241119/riscv32-esp-elf/bin/../lib/gcc/riscv32-esp-elf/14.2.0/../../../../riscv32-esp-elf/bin/ld: The gap between .flash.appdesc and .flash.rodata must not exist to produce the final bin image.
...
```

I am honestly not sure what I am doing, so feel free to take over the pull request in case things aren't right. 