### PR TITLE
Document Docker flag needed on Linux

### DIFF
--- a/Sources/SwiftMatterExamples/Documentation.docc/Tutorials/Setup-Docker.tutorial
+++ b/Sources/SwiftMatterExamples/Documentation.docc/Tutorials/Setup-Docker.tutorial
@@ -60,7 +60,9 @@
       }
 
       @Step {
-        In a new shell, launch the docker container from the previously built image. 
+        In a new shell, launch the docker container from the previously built image.
+
+        If you are running Docker on Linux you also need to add `--add-host=host.docker.internal:host-gateway` to the flags. 
         
         > Important: Be sure to run the container from the root directory of swift-matter-examples.  
 


### PR DESCRIPTION
When you are running Docker on Linux you need to add `--add-host host.docker.internal:host-gateway` to the flags of `docker run` to be able to connect to the host as explained in [this StackOverflow answer](https://stackoverflow.com/a/24326540/2493714). We need to be able to connect to the host so we can use the `esp_rfc2217_server.py` running on the host.