### PR TITLE
Pin `esp-idf` and `esp-matter` versions in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN pip install --upgrade cmake
 RUN mkdir -p ~/esp \
   && cd ~/esp \
   && git clone \
-    --branch master \
+    --branch v5.2.3 \
     --depth 1 \
     --shallow-submodules \
     --recursive https://github.com/espressif/esp-idf.git \
@@ -40,7 +40,7 @@ RUN apt-get update \
 RUN mkdir -p ~/esp \
   && cd ~/esp \
   && git clone \
-    --branch release/v1.2 \
+    --branch release/v1.4 \
     --depth 1 \
     --shallow-submodules \
     --recursive https://github.com/espressif/esp-matter.git \


### PR DESCRIPTION
I ran into a lot of issues trying to build `led-blink` and i documented one of them in #40. These issues came down to two problems:
1. We were using a old version of `esp-matter` (1.2 when 1.4 is the newest).
2. We were using the `master`-branch of `esp-idf`.

Updating `esp-matter` is pretty self explanatory but the reason I pinned `esp-idf` to `v5.2.3` is because it's recommended in their [README](https://github.com/espressif/esp-matter/blob/main/README.md). I ran into an [issue](https://github.com/espressif/esp-matter/issues/1264) documented on the `esp-matter` GitHub repo and after pinning the version as recommended there the build was successful.