### PR TITLE
Fix smart light example; fix attribute access

### DIFF
--- a/smart-light/Matter/Matter.swift
+++ b/smart-light/Matter/Matter.swift
@@ -140,7 +140,7 @@ extension Matter {
       var lightConfig = esp_matter.endpoint.extended_color_light.config_t()
       lightConfig.on_off.on_off = true
       lightConfig.level_control.current_level = .init(64)
-      lightConfig.level_control.lighting.start_up_current_level = .init(64)
+      lightConfig.level_control_lighting.start_up_current_level = .init(64)
       lightConfig.color_control.color_mode =
         chip.app.Clusters.ColorControl.ColorMode.colorTemperature.rawValue
       lightConfig.color_control.enhanced_color_mode =

--- a/smart-light/Matter/Node.swift
+++ b/smart-light/Matter/Node.swift
@@ -114,11 +114,14 @@ struct Endpoint: MatterEndpoint {
   }
 
   func `as`<T: MatterConreteEndpoint>(_ type: T.Type) -> T? {
-    var count = UInt8(0)
     let expected = T.deviceTypeId
-    let ids = esp_matter.endpoint.get_device_type_ids(endpoint, &count)
-    for id in UnsafeMutableBufferPointer(start: ids, count: Int(count)) {
-      if id == expected {
+    let count = esp_matter.endpoint.get_device_type_count(endpoint)
+    for i in 0..<count {
+      var deviceTypeId: UInt32 = 0
+      var deviceTypeVersion: UInt8 = 0
+      let err = esp_matter.endpoint.get_device_type_at_index(
+        endpoint, i, &deviceTypeId, &deviceTypeVersion)
+      if err == ESP_OK && deviceTypeId == expected {
         return T(endpoint)
       }
     }


### PR DESCRIPTION
Close #47 

Tested on a ESP32c6 Zero from Waveshare.

Using ESP-IDF v5.3.2
ESP-Matter v1.5